### PR TITLE
メッセージ投稿：スクロール制御

### DIFF
--- a/pages/browser/[...pathes]/components/StreamBar/index.tsx
+++ b/pages/browser/[...pathes]/components/StreamBar/index.tsx
@@ -1,5 +1,5 @@
 import type { FormEvent } from 'react'
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import { useApi } from '~/hooks'
 import type { BrowserProject, ProjectApiData } from '~/server/types'
@@ -64,6 +64,7 @@ export const StreamBar = ({
 }) => {
   const { api, onErr } = useApi()
   const [content, setMessage] = useState('')
+  const scrollBottomRef = useRef<HTMLDivElement>(null)
 
   const userName = 'Test Name'
   const postMessage = useCallback(
@@ -72,7 +73,7 @@ export const StreamBar = ({
       if (!content) return
       if (!project.openedTabId) return
       if (!projectApiData.revisions) return
-      const res = api.browser.works
+      const res = await api.browser.works
         ._workId(project.openedTabId)
         .revisions._revisionId(projectApiData.revisions.slice(-1)[0].id)
         .post({ body: { content, userName } })
@@ -80,16 +81,21 @@ export const StreamBar = ({
 
       if (!res) return
 
+      projectApiData.messages?.push(res.body)
       setMessage('')
     },
     [content, project, projectApiData]
   )
+  useEffect(() => {
+    scrollBottomRef?.current?.scrollIntoView()
+  }, [projectApiData.messages?.length])
 
   return (
     <Container>
       <StreamBox>
         {projectApiData.messages &&
           projectApiData.messages.map((d, i) => <CommentBlock key={i} message={d} />)}
+        <div ref={scrollBottomRef} />
       </StreamBox>
       <MessageBox>
         <InputForm

--- a/pages/browser/[...pathes]/usePage.ts
+++ b/pages/browser/[...pathes]/usePage.ts
@@ -84,7 +84,9 @@ export const usePage = () => {
 
     const data = apiWholeData.projects?.find((p) => p.id === currentProject.id)
     const desks = apiWholeData.desksList.find((d) => d.projectId === currentProject.id)?.desks
-    const revisionId = apiWholeData.revisionsList.map((d) => d.revisions.slice(-1)[0].id)[0]
+    const revisions = apiWholeData.revisionsList.find(
+      (d) => d.workId === currentProject.openedTabId
+    )?.revisions
 
     return (
       data &&
@@ -92,9 +94,10 @@ export const usePage = () => {
         projectId: currentProject.id,
         name: data.name,
         desks,
-        revisions: apiWholeData.revisionsList.find((d) => d.workId === currentProject.openedTabId)
-          ?.revisions,
-        messages: apiWholeData.messagesList.find((d) => d.revisionId === revisionId)?.messages,
+        revisions: revisions,
+        messages: apiWholeData.messagesList.find(
+          (d) => d.revisionId === revisions?.slice(-1)[0]?.id
+        )?.messages,
       }
     )
   }, [apiWholeData, currentProject])

--- a/pages/browser/[...pathes]/usePage.ts
+++ b/pages/browser/[...pathes]/usePage.ts
@@ -84,9 +84,6 @@ export const usePage = () => {
 
     const data = apiWholeData.projects?.find((p) => p.id === currentProject.id)
     const desks = apiWholeData.desksList.find((d) => d.projectId === currentProject.id)?.desks
-    const revisions = apiWholeData.revisionsList.find(
-      (d) => d.workId === currentProject.openedTabId
-    )?.revisions
 
     return (
       data &&
@@ -94,9 +91,14 @@ export const usePage = () => {
         projectId: currentProject.id,
         name: data.name,
         desks,
-        revisions: revisions,
+        revisions: apiWholeData.revisionsList.find((d) => d.workId === currentProject.openedTabId)
+          ?.revisions,
         messages: apiWholeData.messagesList.find(
-          (d) => d.revisionId === revisions?.slice(-1)[0]?.id
+          (d) =>
+            d.revisionId ===
+            apiWholeData.revisionsList
+              .find((d) => d.workId === currentProject.openedTabId)
+              ?.revisions?.slice(-1)[0]?.id
         )?.messages,
       }
     )


### PR DESCRIPTION
- 新規メッセージ投稿時にスクロールが最下部に動く機能
    - 別work読み込み後、Revisionが存在するworkに移動した場合にも
        メッセージが表示されるように修正
    - 投稿したメッセージが即時表示されるように修正

![image](https://user-images.githubusercontent.com/52160187/134940366-fa556e7a-d216-4458-a64a-2121da663042.png)

↓

![image](https://user-images.githubusercontent.com/52160187/134940493-74ee6c38-a01b-426b-872a-9d9caaf7e9a3.png)
